### PR TITLE
fix(research): Add polling support for async research tasks

### DIFF
--- a/skills/tavily/research/scripts/research.sh
+++ b/skills/tavily/research/scripts/research.sh
@@ -4,14 +4,16 @@
 # Example: ./research.sh '{"input": "quantum computing trends", "model": "pro"}' results.md
 
 set -e
+set -o pipefail
 
 JSON_INPUT="$1"
 OUTPUT_FILE="$2"
 
 # Polling configuration
-MAX_ATTEMPTS=120         # Maximum polling attempts (10 minutes total)
+MAX_ATTEMPTS=120         # Maximum polling attempts (10 minutes of polling)
 POLL_INTERVAL=5          # Seconds between polls
 INITIAL_TIMEOUT=30       # Initial request timeout in seconds
+MAX_CONSECUTIVE_FAILURES=5  # Max consecutive failures before aborting
 
 if [ -z "$JSON_INPUT" ]; then
     echo "Usage: ./research.sh '<json>' [output_file]"
@@ -63,15 +65,49 @@ INPUT=$(echo "$JSON_INPUT" | jq -r '.input')
 MODEL=$(echo "$JSON_INPUT" | jq -r '.model // "auto"')
 
 echo "Researching: $INPUT (model: $MODEL)"
-echo "This may take 30-120 seconds..."
+echo "This may take 30 seconds to several minutes..."
 
-# Initial research request
-RESPONSE=$(curl -s --max-time "$INITIAL_TIMEOUT" --request POST \
+# Create temp file for response
+TEMP_RESPONSE=$(mktemp)
+trap "rm -f $TEMP_RESPONSE" EXIT
+
+# Initial research request with proper error handling
+HTTP_CODE=$(curl -s -w "%{http_code}" --max-time "$INITIAL_TIMEOUT" \
+    -o "$TEMP_RESPONSE" \
+    --request POST \
     --url https://api.tavily.com/research \
     --header "Authorization: Bearer $TAVILY_API_KEY" \
     --header 'Content-Type: application/json' \
     --header 'x-client-source: claude-code-skill' \
-    --data "$JSON_INPUT" 2>&1)
+    --data "$JSON_INPUT") || CURL_EXIT=$?
+
+# Check curl exit code
+if [ "${CURL_EXIT:-0}" -ne 0 ]; then
+    echo "Error: Network request failed (curl exit code: $CURL_EXIT)"
+    case "$CURL_EXIT" in
+        6) echo "Could not resolve host. Check your internet connection." ;;
+        7) echo "Failed to connect to api.tavily.com. The service may be down." ;;
+        28) echo "Request timed out after ${INITIAL_TIMEOUT}s. Try again later." ;;
+        60) echo "SSL certificate verification failed." ;;
+        *) echo "Network error occurred." ;;
+    esac
+    exit 1
+fi
+
+# Check HTTP status code
+if [ "$HTTP_CODE" -ge 400 ]; then
+    echo "Error: API returned HTTP $HTTP_CODE"
+    case "$HTTP_CODE" in
+        401) echo "Unauthorized. Check your TAVILY_API_KEY." ;;
+        403) echo "Forbidden. Your API key may not have access to this resource." ;;
+        429) echo "Rate limited. Too many requests." ;;
+        500|502|503) echo "Server error. The Tavily service may be experiencing issues." ;;
+    esac
+    cat "$TEMP_RESPONSE" 2>/dev/null || true
+    exit 1
+fi
+
+RESPONSE=$(cat "$TEMP_RESPONSE")
 
 # Check if response is valid JSON
 if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
@@ -84,8 +120,8 @@ fi
 STATUS=$(echo "$RESPONSE" | jq -r '.status // empty')
 REQUEST_ID=$(echo "$RESPONSE" | jq -r '.request_id // empty')
 
-# If already completed or failed, output result
-if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
+# If already completed, output result
+if [ "$STATUS" = "completed" ]; then
     if [ -n "$OUTPUT_FILE" ]; then
         echo "$RESPONSE" > "$OUTPUT_FILE"
         echo "Results saved to: $OUTPUT_FILE"
@@ -95,27 +131,77 @@ if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
     exit 0
 fi
 
-# If pending/processing and we have a request_id, start polling
+# If failed, output error and exit with error code
+if [ "$STATUS" = "failed" ]; then
+    echo "Research failed!"
+    ERROR=$(echo "$RESPONSE" | jq -r '.error // "Unknown error"')
+    echo "Error: $ERROR"
+    if [ -n "$OUTPUT_FILE" ]; then
+        echo "$RESPONSE" > "$OUTPUT_FILE"
+    fi
+    exit 1
+fi
+
+# If pending/processing/in_progress and we have a request_id, start polling
 if [ -n "$REQUEST_ID" ] && [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
     echo "Research task started (request_id: $REQUEST_ID)"
     echo "Status: $STATUS - polling for results..."
 
     ATTEMPT=0
+    CONSECUTIVE_FAILURES=0
+    UNKNOWN_STATUS_COUNT=0
     while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
         ATTEMPT=$((ATTEMPT + 1))
         sleep "$POLL_INTERVAL"
 
-        # Poll for status
-        POLL_RESPONSE=$(curl -s --max-time 30 --request GET \
+        # Poll for status with proper error handling
+        HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 30 \
+            -o "$TEMP_RESPONSE" \
+            --request GET \
             --url "https://api.tavily.com/research/$REQUEST_ID" \
             --header "Authorization: Bearer $TAVILY_API_KEY" \
-            --header 'x-client-source: claude-code-skill' 2>&1)
+            --header 'x-client-source: claude-code-skill') || CURL_EXIT=$?
+
+        # Check curl exit code
+        if [ "${CURL_EXIT:-0}" -ne 0 ]; then
+            CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+            echo "Warning: Network error during poll (attempt $ATTEMPT/$MAX_ATTEMPTS, failures: $CONSECUTIVE_FAILURES)"
+            if [ $CONSECUTIVE_FAILURES -ge $MAX_CONSECUTIVE_FAILURES ]; then
+                echo "Error: Too many consecutive network failures"
+                exit 1
+            fi
+            CURL_EXIT=0
+            continue
+        fi
+
+        # Check HTTP status code
+        if [ "$HTTP_CODE" -ge 400 ]; then
+            CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+            echo "Warning: API returned HTTP $HTTP_CODE (attempt $ATTEMPT/$MAX_ATTEMPTS, failures: $CONSECUTIVE_FAILURES)"
+            if [ $CONSECUTIVE_FAILURES -ge $MAX_CONSECUTIVE_FAILURES ]; then
+                echo "Error: Too many consecutive API errors"
+                cat "$TEMP_RESPONSE" 2>/dev/null || true
+                exit 1
+            fi
+            continue
+        fi
+
+        POLL_RESPONSE=$(cat "$TEMP_RESPONSE")
 
         # Check if response is valid JSON
         if ! echo "$POLL_RESPONSE" | jq empty 2>/dev/null; then
-            echo "Warning: Invalid poll response (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+            CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+            echo "Warning: Invalid poll response (attempt $ATTEMPT/$MAX_ATTEMPTS, failures: $CONSECUTIVE_FAILURES)"
+            echo "Response was: $POLL_RESPONSE"
+            if [ $CONSECUTIVE_FAILURES -ge $MAX_CONSECUTIVE_FAILURES ]; then
+                echo "Error: Too many consecutive invalid responses"
+                exit 1
+            fi
             continue
         fi
+
+        # Reset failure counter on successful response
+        CONSECUTIVE_FAILURES=0
 
         STATUS=$(echo "$POLL_RESPONSE" | jq -r '.status // empty')
 
@@ -140,21 +226,40 @@ if [ -n "$REQUEST_ID" ] && [ "$STATUS" != "completed" ] && [ "$STATUS" != "faile
                 exit 1
                 ;;
             pending|processing|in_progress)
+                UNKNOWN_STATUS_COUNT=0
                 echo "Status: $STATUS (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
                 ;;
             *)
-                echo "Unknown status: $STATUS (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+                UNKNOWN_STATUS_COUNT=$((UNKNOWN_STATUS_COUNT + 1))
+                echo "Warning: Unknown status '$STATUS' (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+                if [ $UNKNOWN_STATUS_COUNT -ge $MAX_CONSECUTIVE_FAILURES ]; then
+                    echo "Error: Received unknown status $UNKNOWN_STATUS_COUNT times. The API may have changed."
+                    echo "Last response:"
+                    echo "$POLL_RESPONSE"
+                    exit 1
+                fi
                 ;;
         esac
     done
 
     echo "Error: Polling timeout after $MAX_ATTEMPTS attempts"
+    echo "Last known status: ${STATUS:-unknown}"
+    echo "Request ID: $REQUEST_ID"
+    echo "Consider checking the Tavily dashboard for this request."
     echo "Last response:"
     echo "$POLL_RESPONSE"
     exit 1
 fi
 
-# If no request_id, output the original response (might be an error or immediate result)
+# Fallback: output original response when no request_id available
+# This handles legacy API responses or unexpected formats
+if [ -z "$REQUEST_ID" ] && [ "$STATUS" != "completed" ]; then
+    echo "Warning: Unexpected API response (no request_id, status: ${STATUS:-none})"
+    echo "Response:"
+    echo "$RESPONSE"
+    exit 1
+fi
+
 if [ -n "$OUTPUT_FILE" ]; then
     echo "$RESPONSE" > "$OUTPUT_FILE"
     echo "Results saved to: $OUTPUT_FILE"

--- a/skills/tavily/research/scripts/research.sh
+++ b/skills/tavily/research/scripts/research.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tavily Research API script
+# Tavily Research API script with polling support
 # Usage: ./research.sh '{"input": "your research query", ...}' [output_file]
 # Example: ./research.sh '{"input": "quantum computing trends", "model": "pro"}' results.md
 
@@ -7,6 +7,11 @@ set -e
 
 JSON_INPUT="$1"
 OUTPUT_FILE="$2"
+
+# Polling configuration
+MAX_ATTEMPTS=120         # Maximum polling attempts (10 minutes total)
+POLL_INTERVAL=5          # Seconds between polls
+INITIAL_TIMEOUT=30       # Initial request timeout in seconds
 
 if [ -z "$JSON_INPUT" ]; then
     echo "Usage: ./research.sh '<json>' [output_file]"
@@ -60,13 +65,96 @@ MODEL=$(echo "$JSON_INPUT" | jq -r '.model // "auto"')
 echo "Researching: $INPUT (model: $MODEL)"
 echo "This may take 30-120 seconds..."
 
-RESPONSE=$(curl -sN --request POST \
+# Initial research request
+RESPONSE=$(curl -s --max-time "$INITIAL_TIMEOUT" --request POST \
     --url https://api.tavily.com/research \
     --header "Authorization: Bearer $TAVILY_API_KEY" \
     --header 'Content-Type: application/json' \
     --header 'x-client-source: claude-code-skill' \
     --data "$JSON_INPUT" 2>&1)
 
+# Check if response is valid JSON
+if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
+    echo "Error: Invalid response from API"
+    echo "$RESPONSE"
+    exit 1
+fi
+
+# Extract status and request_id
+STATUS=$(echo "$RESPONSE" | jq -r '.status // empty')
+REQUEST_ID=$(echo "$RESPONSE" | jq -r '.request_id // empty')
+
+# If already completed or failed, output result
+if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
+    if [ -n "$OUTPUT_FILE" ]; then
+        echo "$RESPONSE" > "$OUTPUT_FILE"
+        echo "Results saved to: $OUTPUT_FILE"
+    else
+        echo "$RESPONSE"
+    fi
+    exit 0
+fi
+
+# If pending/processing and we have a request_id, start polling
+if [ -n "$REQUEST_ID" ] && [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+    echo "Research task started (request_id: $REQUEST_ID)"
+    echo "Status: $STATUS - polling for results..."
+
+    ATTEMPT=0
+    while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+        ATTEMPT=$((ATTEMPT + 1))
+        sleep "$POLL_INTERVAL"
+
+        # Poll for status
+        POLL_RESPONSE=$(curl -s --max-time 30 --request GET \
+            --url "https://api.tavily.com/research/$REQUEST_ID" \
+            --header "Authorization: Bearer $TAVILY_API_KEY" \
+            --header 'x-client-source: claude-code-skill' 2>&1)
+
+        # Check if response is valid JSON
+        if ! echo "$POLL_RESPONSE" | jq empty 2>/dev/null; then
+            echo "Warning: Invalid poll response (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+            continue
+        fi
+
+        STATUS=$(echo "$POLL_RESPONSE" | jq -r '.status // empty')
+
+        case "$STATUS" in
+            completed)
+                echo "Research completed!"
+                if [ -n "$OUTPUT_FILE" ]; then
+                    echo "$POLL_RESPONSE" > "$OUTPUT_FILE"
+                    echo "Results saved to: $OUTPUT_FILE"
+                else
+                    echo "$POLL_RESPONSE"
+                fi
+                exit 0
+                ;;
+            failed)
+                echo "Research failed!"
+                ERROR=$(echo "$POLL_RESPONSE" | jq -r '.error // "Unknown error"')
+                echo "Error: $ERROR"
+                if [ -n "$OUTPUT_FILE" ]; then
+                    echo "$POLL_RESPONSE" > "$OUTPUT_FILE"
+                fi
+                exit 1
+                ;;
+            pending|processing|in_progress)
+                echo "Status: $STATUS (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+                ;;
+            *)
+                echo "Unknown status: $STATUS (attempt $ATTEMPT/$MAX_ATTEMPTS)"
+                ;;
+        esac
+    done
+
+    echo "Error: Polling timeout after $MAX_ATTEMPTS attempts"
+    echo "Last response:"
+    echo "$POLL_RESPONSE"
+    exit 1
+fi
+
+# If no request_id, output the original response (might be an error or immediate result)
 if [ -n "$OUTPUT_FILE" ]; then
     echo "$RESPONSE" > "$OUTPUT_FILE"
     echo "Results saved to: $OUTPUT_FILE"


### PR DESCRIPTION
## Summary

- Add polling support for async research tasks that return `status: "pending"` with a `request_id`
- Poll `GET /research/{request_id}` until task completes or fails
- Add timeout handling and JSON response validation

Fixes #7

## Details

The Research API may process requests asynchronously, returning `status: "pending"` instead of immediate results. This change adds polling logic to handle this case, aligning the shell script behavior with the Python SDK's `get_research(request_id)` method.

### Changes

| Feature | Before | After |
|---------|--------|-------|
| Async handling | None | Polls until completion |
| Request timeout | None | 30s initial, 30s per poll |
| JSON validation | None | Validates all responses |
| Max polling time | N/A | 10 minutes (120 × 5s) |

## Test plan

- [ ] Test with a query that returns immediately (`status: "completed"`)
- [ ] Test with a query that requires async processing (`status: "pending"`)
- [ ] Test timeout behavior with invalid API key
- [ ] Test output file saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)