### PR TITLE
feat: add `skills install` to CLI

### DIFF
--- a/tavily_cli/README.md
+++ b/tavily_cli/README.md
@@ -75,6 +75,9 @@ tvly login
 
 # Check auth status
 tvly auth
+
+# Install agent skills
+tvly skills install
 ```
 
 ### 2. Interactive Mode

--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -11,6 +11,7 @@ from tavily_cli.commands.extract import extract
 from tavily_cli.commands.map_cmd import map_urls
 from tavily_cli.commands.research import research
 from tavily_cli.commands.search import search
+from tavily_cli.commands.skills import skills
 
 
 @click.group(invoke_without_command=True)
@@ -92,6 +93,8 @@ def _print_welcome() -> None:
     commands.append("    tvly research ", style="#9BC0AE")
     commands.append('"your query"', style="dim")
     commands.append("          Deep research\n")
+    commands.append("    tvly skills", style="#9BC0AE")
+    commands.append("                          Install agent skills\n")
 
     console.print(commands)
     console.print("  [dim]Add --json to any command for machine-readable output.[/dim]")
@@ -146,6 +149,7 @@ cli.add_command(extract)
 cli.add_command(crawl)
 cli.add_command(map_urls)
 cli.add_command(research)
+cli.add_command(skills)
 
 
 def main() -> None:

--- a/tavily_cli/cli.py
+++ b/tavily_cli/cli.py
@@ -93,8 +93,8 @@ def _print_welcome() -> None:
     commands.append("    tvly research ", style="#9BC0AE")
     commands.append('"your query"', style="dim")
     commands.append("          Deep research\n")
-    commands.append("    tvly skills", style="#9BC0AE")
-    commands.append("                          Install agent skills\n")
+    commands.append("    tvly skills install", style="#9BC0AE")
+    commands.append("                  Install agent skills\n")
 
     console.print(commands)
     console.print("  [dim]Add --json to any command for machine-readable output.[/dim]")

--- a/tavily_cli/commands/auth.py
+++ b/tavily_cli/commands/auth.py
@@ -118,7 +118,31 @@ def _print_login_success(method: str, detail: str) -> None:
     hints.append("    tvly research ", style="#9BC0AE")
     hints.append('"deep dive topic"', style="dim")
     hints.append("\n")
+    hints.append("    tvly skills install", style="#9BC0AE")
+    hints.append("\n")
     console.print(hints)
+
+    _prompt_skills_install()
+
+
+def _prompt_skills_install() -> None:
+    """Ask the user if they'd like to install Tavily agent skills."""
+    import shutil
+
+    from tavily_cli.theme import console
+
+    if not shutil.which("npx"):
+        return
+
+    if not click.confirm("  Install Tavily agent skills? (for Claude Code, Cursor, etc.)", default=True):
+        console.print()
+        console.print("  [dim]You can install later with:[/dim] [#9BC0AE]tvly skills install[/#9BC0AE]")
+        console.print()
+        return
+
+    console.print()
+    from tavily_cli.commands.skills import run_skills_install
+    run_skills_install()
 
 
 @click.command()

--- a/tavily_cli/commands/skills.py
+++ b/tavily_cli/commands/skills.py
@@ -1,4 +1,4 @@
-"""tvly skills — install Tavily agent skills via npx."""
+"""tvly skills — manage Tavily agent skills via npx."""
 
 from __future__ import annotations
 
@@ -11,20 +11,25 @@ import click
 SKILLS_REPO = "https://github.com/tavily-ai/skills"
 
 
-@click.command(
+@click.group()
+def skills() -> None:
+    """Manage Tavily agent skills for Claude Code, Cursor, and other AI agents."""
+
+
+@skills.command(
     context_settings={"ignore_unknown_options": True},
 )
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
-def skills(extra_args: tuple[str, ...]) -> None:
-    """Install Tavily agent skills for Claude Code, Cursor, and other AI agents.
+def install(extra_args: tuple[str, ...]) -> None:
+    """Install Tavily agent skills into your project.
 
     Runs: npx skills add https://github.com/tavily-ai/skills
 
     Any extra flags are forwarded to `npx skills`, for example:
 
     \b
-        tvly skills --global          Install skills globally
-        tvly skills --skill tavily-search   Install a specific skill
+        tvly skills install --global              Install skills globally
+        tvly skills install --skill tavily-search  Install a specific skill
     """
     from tavily_cli.theme import err_console
 
@@ -36,6 +41,6 @@ def skills(extra_args: tuple[str, ...]) -> None:
         err_console.print()
         raise SystemExit(1)
 
-    cmd = ["npx", "skills", "add", SKILLS_REPO, *extra_args]
+    cmd = ["npx", "-y", "skills", "add", SKILLS_REPO, *extra_args]
     result = subprocess.run(cmd)
     raise SystemExit(result.returncode)

--- a/tavily_cli/commands/skills.py
+++ b/tavily_cli/commands/skills.py
@@ -23,13 +23,28 @@ def skills() -> None:
 def install(extra_args: tuple[str, ...]) -> None:
     """Install Tavily agent skills into your project.
 
-    Runs: npx skills add https://github.com/tavily-ai/skills
+    Runs: npx -y skills add https://github.com/tavily-ai/skills
 
-    Any extra flags are forwarded to `npx skills`, for example:
+    All flags after `install` are forwarded directly to `npx skills add`.
+    Common options:
 
     \b
-        tvly skills install --global              Install skills globally
+        -g, --global             Install globally (user-level)
+        -a, --agent <agents>     Target specific agents (e.g. claude-code cursor)
+        -s, --skill <skills>     Install specific skills (e.g. tavily-search)
+        -y, --yes                Skip confirmation prompts
+        --all                    All skills, all agents, no prompts
+        --full-depth             Search all subdirectories
+        --copy                   Copy files instead of symlinking
+
+    \b
+    Examples:
+        tvly skills install                        Install interactively
+        tvly skills install --global               Install globally
         tvly skills install --skill tavily-search  Install a specific skill
+        tvly skills install --all                  Install everything, no prompts
+
+    Full docs: https://github.com/vercel-labs/skills
     """
     from tavily_cli.theme import err_console
 
@@ -41,6 +56,6 @@ def install(extra_args: tuple[str, ...]) -> None:
         err_console.print()
         raise SystemExit(1)
 
-    cmd = ["npx", "-y", "skills", "add", SKILLS_REPO, *extra_args]
+    cmd = ["npx", "-y", "skills", "add", SKILLS_REPO, "--yes", "--full-depth", "--global", *extra_args]
     result = subprocess.run(cmd)
     raise SystemExit(result.returncode)

--- a/tavily_cli/commands/skills.py
+++ b/tavily_cli/commands/skills.py
@@ -48,14 +48,26 @@ def install(extra_args: tuple[str, ...]) -> None:
     """
     from tavily_cli.theme import err_console
 
+    returncode = run_skills_install(extra_args)
+    raise SystemExit(returncode)
+
+
+def run_skills_install(extra_args: tuple[str, ...] = ()) -> int:
+    """Run `npx skills add` and return the process exit code.
+
+    Reusable so other commands (e.g. login) can trigger a skills install
+    without going through Click dispatch.
+    """
+    from tavily_cli.theme import err_console
+
     if not shutil.which("npx"):
         err_console.print()
         err_console.print("  [#FAA2FB]> npx not found.[/#FAA2FB]")
         err_console.print()
         err_console.print("  Install Node.js to get npx: [link=https://nodejs.org]nodejs.org[/link]")
         err_console.print()
-        raise SystemExit(1)
+        return 1
 
     cmd = ["npx", "-y", "skills", "add", SKILLS_REPO, "--yes", "--full-depth", "--global", *extra_args]
     result = subprocess.run(cmd)
-    raise SystemExit(result.returncode)
+    return result.returncode

--- a/tavily_cli/commands/skills.py
+++ b/tavily_cli/commands/skills.py
@@ -1,0 +1,41 @@
+"""tvly skills — install Tavily agent skills via npx."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import click
+
+
+SKILLS_REPO = "https://github.com/tavily-ai/skills"
+
+
+@click.command(
+    context_settings={"ignore_unknown_options": True},
+)
+@click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
+def skills(extra_args: tuple[str, ...]) -> None:
+    """Install Tavily agent skills for Claude Code, Cursor, and other AI agents.
+
+    Runs: npx skills add https://github.com/tavily-ai/skills
+
+    Any extra flags are forwarded to `npx skills`, for example:
+
+    \b
+        tvly skills --global          Install skills globally
+        tvly skills --skill tavily-search   Install a specific skill
+    """
+    from tavily_cli.theme import err_console
+
+    if not shutil.which("npx"):
+        err_console.print()
+        err_console.print("  [#FAA2FB]> npx not found.[/#FAA2FB]")
+        err_console.print()
+        err_console.print("  Install Node.js to get npx: [link=https://nodejs.org]nodejs.org[/link]")
+        err_console.print()
+        raise SystemExit(1)
+
+    cmd = ["npx", "skills", "add", SKILLS_REPO, *extra_args]
+    result = subprocess.run(cmd)
+    raise SystemExit(result.returncode)

--- a/tavily_cli/repl.py
+++ b/tavily_cli/repl.py
@@ -20,7 +20,7 @@ from tavily_cli.theme import LOGO
 err_console = Console(stderr=True)
 
 # Commands that the REPL recognises (mapped by the CLI group).
-_REPL_COMMANDS = {"search", "extract", "crawl", "map", "research", "login", "logout", "auth"}
+_REPL_COMMANDS = {"search", "extract", "crawl", "map", "research", "login", "logout", "auth", "skills"}
 
 
 def _print_banner() -> None:
@@ -52,6 +52,8 @@ def _print_banner() -> None:
     tips.append("research ", style="#9BC0AE")
     tips.append('"topic"', style="dim")
     tips.append("  |  ", style="dim")
+    tips.append("skills install", style="#9BC0AE")
+    tips.append("  |  ", style="dim")
     tips.append("help", style="#9BC0AE")
     tips.append("  |  ", style="dim")
     tips.append("exit", style="#9BC0AE")
@@ -80,6 +82,8 @@ def _print_help() -> None:
     cmds.append("                        Clear credentials\n")
     cmds.append("    auth", style="#9BC0AE")
     cmds.append("                          Auth status\n")
+    cmds.append("    skills install", style="#9BC0AE")
+    cmds.append("                  Install agent skills\n")
     cmds.append("    exit / quit / Ctrl+C", style="#9BC0AE")
     cmds.append("          Leave\n")
     err_console.print(cmds)


### PR DESCRIPTION
## `tvly skills install` — install agent skills from the CLI

### Summary

- Adds a `tvly skills install` command that shells out to `npx skills add https://github.com/tavily-ai/skills`, letting users install Tavily agent skills for Claude Code, Cursor, and other AI agents directly from the CLI.
- All `npx skills add` flags (`--global`, `--agent`, `--skill`, `--all`, `--full-depth`, etc.) are forwarded verbatim, keeping the user in control.
- The command is surfaced in the REPL banner, REPL help, and the CLI welcome screen.
- The user is prompted to install skills after running `tvly login`.

### Usage

```bash
tvly skills install                        # install interactively
tvly skills install --global               # install globally
tvly skills install --skill tavily-search  # install a specific skill
tvly skills install --all                  # install everything, no prompts
```

### Test plan

- [x] Run `tvly skills install --help` and verify the available options and docs link are shown
- [x] Run `tvly skills install` and confirm it delegates to `npx skills add` correctly
- [x] Run `tvly` (REPL) and verify `skills install` appears in the banner tips and `help` output
- [x] Verify the command errors gracefully when `npx` is not on PATH