### PR TITLE
chore: bump version to v0.1.1

### DIFF
--- a/tavily_cli/__init__.py
+++ b/tavily_cli/__init__.py
@@ -1,3 +1,3 @@
 """Tavily CLI — search, extract, crawl, map, and research from the command line."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
According to <https://pypi.org/project/tavily-cli> and <https://github.com/tavily-ai/skills/commit/4f67f87b011206a184e0f9de616cf54bbd05c5cb>, the current version is v0.1.1, but the `tvly --version` is returning `0.1.0`, this is causing user confusing. This PR fixes the issue.